### PR TITLE
Bug fixes and CI addition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Mount bazel cache
+        uses: actions/cache@v1
+        with:
+          path: "/home/runner/.cache/bazel"
+          key: ${{ runner.os }}-bazel
+
+      # Runs a single command using the runners shell
+      - name: Build
+        run: bazelisk build //...

--- a/BUILD
+++ b/BUILD
@@ -1,8 +1,13 @@
 filegroup(
-    name = "clang_tidy_config",
+    name = "clang_tidy_config_default",
     data = [
         ".clang-tidy",
         # '//example:clang_tidy_config', # add package specific configs if needed
     ],
+)
+
+label_flag(
+    name = "clang_tidy_config",
+    build_setting_default = ":clang_tidy_config_default",
     visibility = ["//visibility:public"],
 )

--- a/README.md
+++ b/README.md
@@ -6,15 +6,76 @@ and take advantage of Bazels powerful cache mechanism.
 
 Usage:
 
+```py
+# //:WORKSPACE
+load(
+    "@bazel_tools//tools/build_defs/repo:git.bzl",
+    "git_repository",
+)
+
+git_repository(
+       name = "bazel_clang_tidy",
+       commit = "69aa13e6d7cf102df70921c66be15d4592251e56",
+       remote = "https://github.com/erenon/bazel_clang_tidy.git",
+)
 ```
-bazel build //... --aspects clang_tidy/clang_tidy.bzl%clang_tidy_aspect --output_groups=report
+
+You can now compile using the default clang tidy configuration provided using
+the following command;
+
+```
+bazel build //... \
+  --aspects @bazel_clang_tidy//clang_tidy:clang_tidy.bzl%clang_tidy_aspect \
+  --output_groups=report
+```
+
+If you would like to override the default clang tidy configuration then you can
+reconfigure the default target from the command line. To do this you must first
+make a filegroup target that has the .clang-tidy config file as a data
+dependency.
+
+```py
+# //:BUILD
+filegroup(
+       name = "clang_tidy_config",
+       data = [".clang_tidy"],
+       visibility = ["//visibility:public"],
+)
+```
+
+Now you can override the default config file in this repository using
+a command line flag;
+
+```sh
+bazel build //... \
+  --aspects @bazel_clang_tidy//clang_tidy:clang_tidy.bzl%clang_tidy_aspect \
+  --output_groups=report \
+  --@bazel_clang_tidy//:clang_tidy_config=//:clang_tidy_config
+```
+
+Now if you don't want to type this out every time, it is recommended that you
+add a config in your .bazelrc that matches this command line;
+
+```
+# Required for bazel_clang_tidy to operate as expected
+build:clang-tidy --aspects @bazel_clang_tidy//clang_tidy:clang_tidy.bzl%clang_tidy_aspect
+build:clang-tidy --output_groups=report
+
+# Optionally override the .clang-tidy config file target
+build:clang-tidy --@bazel_clang_tidy//:clang_tidy_config=//:clang_tidy_config
+```
+
+Now from the command line this is a lot nicer to use;
+
+```sh
+bazel build //... --config clang-tidy
 ```
 
 ## Features
 
- - Run clang-tidy on any C++ target
- - Run clang-tidy without also building the target
- - Use Bazel to cache clang-tidy reports: recompute stale reports only
+- Run clang-tidy on any C++ target
+- Run clang-tidy without also building the target
+- Use Bazel to cache clang-tidy reports: recompute stale reports only
 
 ## Install
 
@@ -25,20 +86,20 @@ Edit `.clang-tidy` as needed.
 
 To see the tool in action:
 
- 1. Clone the repository
- 2. Run clang-tidy:
+1.  Clone the repository
+2.  Run clang-tidy:
 
         bazel build //example:app --aspects clang_tidy/clang_tidy.bzl%clang_tidy_aspect --output_groups=report
 
- 3. Check the error:
+3.  Check the error:
 
         lib.cpp:4:43: error: the parameter 'name' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors] std::string lib_get_greet_for(std::string name)
         Aspect //clang_tidy:clang_tidy.bzl%clang_tidy_aspect of //example:app failed to build
 
- 4. Fix the error by changing `lib.cpp` only.
- 5. Re-run clang-tidy with the same command. Observe that it does not run clang-tidy for `app.cpp`: the cached report is re-used.
+4.  Fix the error by changing `lib.cpp` only.
+5.  Re-run clang-tidy with the same command. Observe that it does not run clang-tidy for `app.cpp`: the cached report is re-used.
 
 ## Requirements
 
- - Bazel 4.0 or newer (might work with older versions)
- - clang-tidy on $PATH. (if not, edit `run_clang_tidy.sh`)
+- Bazel 4.0 or newer (might work with older versions)
+- clang-tidy on $PATH. (if not, edit `run_clang_tidy.sh`)

--- a/clang_tidy/clang_tidy.bzl
+++ b/clang_tidy/clang_tidy.bzl
@@ -109,4 +109,5 @@ clang_tidy_aspect = aspect(
         "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
         "_clang_tidy": attr.label(default = Label("//clang_tidy:clang_tidy")),
     },
+    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
 )


### PR DESCRIPTION
Really excited to finally pull this into our build! Great job here.

This change set adds;
- Bazel format and linter targets
- Fixes bug where rule did not specify the toolchain type that was used but requested a toolchain
- Ensures the linters are run in the github actions CI
- Adds a dependency injection point so that the .clang-tidy filegroup targets can be overriden from the command line
- Adds docs about ^^

I'm happy to break these out into seperate PR's if that is easier.