### PR TITLE
Fix builds with matching Bazel target names

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,9 +1,10 @@
+UseColor: true
 
-Checks: "\
-  bugprone-*,\
-  cppcoreguidelines-*,\
-  google-*,\
-  performance-*"
+Checks: >
+    bugprone-*,
+    cppcoreguidelines-*,
+    google-*,
+    performance-*,
 
 HeaderFilterRegex: ".*"
 

--- a/clang_tidy/clang_tidy.bzl
+++ b/clang_tidy/clang_tidy.bzl
@@ -6,7 +6,10 @@ def _run_tidy(ctx, exe, flags, compilation_context, infile, discriminator):
     args = ctx.actions.args()
 
     # specify the output file - twice
-    outfile = ctx.actions.declare_file(infile.path + "." + discriminator + ".clang-tidy.yaml")
+    outfile = ctx.actions.declare_file(
+        "bazel_clang_tidy_" + infile.path + "." + discriminator + ".clang-tidy.yaml"
+    )
+
     args.add(outfile.path)  # this is consumed by the wrapper script
     args.add("--export-fixes", outfile.path)
 

--- a/example/BUILD
+++ b/example/BUILD
@@ -5,7 +5,7 @@ cc_library(
 )
 
 cc_binary(
-    name = "app",
+    name = "example",
     srcs = ["app.cpp"],
     deps = [":lib"],
 )


### PR DESCRIPTION
Hi,

When I have a target where the name matches the last component of the package path, there are conflicting action output paths.

If I rename `example:app` to `example:example`

```
❯  bazel build --config=clang-tidy //example
ERROR: output path 'bazel-out/darwin-fastbuild/bin/example/example' (belonging to //example:example) is a prefix of output path 'bazel-out/darwin-fastbuild/bin/example/example/lib.cpp.lib.clang-tidy.yaml' (belonging to //example:lib). These actions cannot be simultaneously present; please rename one of the output files or build just one of them
```
I've added a prefix to the tidy action outfile but perhaps you have a different way you would like to solve the problem.