### PR TITLE
feat: add to check headers

### DIFF
--- a/clang_tidy/clang_tidy.bzl
+++ b/clang_tidy/clang_tidy.bzl
@@ -61,6 +61,9 @@ def _rule_sources(ctx):
     if hasattr(ctx.rule.attr, "srcs"):
         for src in ctx.rule.attr.srcs:
             srcs += [src for src in src.files.to_list() if src.is_source]
+    if hasattr(ctx.rule.attr, "hdrs"):
+        for hdr in ctx.rule.attr.hdrs:
+            srcs += [hdr for hdr in hdr.files.to_list() if (hdr.is_source and hdr.extension != "h")]
     return srcs
 
 def _toolchain_flags(ctx):

--- a/clang_tidy/clang_tidy.bzl
+++ b/clang_tidy/clang_tidy.bzl
@@ -63,7 +63,7 @@ def _rule_sources(ctx):
             srcs += [src for src in src.files.to_list() if src.is_source]
     if hasattr(ctx.rule.attr, "hdrs"):
         for hdr in ctx.rule.attr.hdrs:
-            srcs += [hdr for hdr in hdr.files.to_list() if (hdr.is_source and hdr.extension != "h")]
+            srcs += [hdr for hdr in hdr.files.to_list() if hdr.is_source]
     return srcs
 
 def _toolchain_flags(ctx):


### PR DESCRIPTION
Header files, which are not exposed, are not checked by clang-tidy via bazel_clang_tidy.

e.g.
```bzl
cc_library(
    name="test",
    srcs=["*.cpp"], # <- check
    hdrs=["*.hpp"], # <- not check
)
```

It seems that other similar projects checks header files.

https://github.com/grailbio/bazel-compilation-database/blob/6b9329e37295eab431f82af5fe24219865403e0f/aspects.bzl#L78

https://github.com/hedronvision/bazel-compile-commands-extractor/blob/1d21dc390e20ecb24d73e9dbb439e971e0d30337/refresh.template.py#L109

