### PR TITLE
Allow clang-tidy to work with weird PATH setups

### DIFF
--- a/clang_tidy/clang_tidy.bzl
+++ b/clang_tidy/clang_tidy.bzl
@@ -46,6 +46,7 @@ def _run_tidy(ctx, exe, config, flags, compilation_context, infile, discriminato
         executable = exe,
         arguments = [args],
         mnemonic = "ClangTidy",
+        use_default_shell_env = True,
         progress_message = "Run clang-tidy on {}".format(infile.short_path),
     )
     return outfile


### PR DESCRIPTION
The current version of bazel_clang_tidy does not work in situations where you need to set a custom PATH.

This patch is a solution to that problem by enabling bazel's build-in shell environment support.

This fixes #19