### PR TITLE
add support for toolchains with hermetic clang-tidy

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -11,3 +11,27 @@ label_flag(
     build_setting_default = ":clang_tidy_config_default",
     visibility = ["//visibility:public"],
 )
+
+
+filegroup(
+    name = "clang_tidy_executable_default",
+    srcs = [], # empty list: system clang-tidy
+)
+
+label_flag(
+    name = "clang_tidy_executable",
+    build_setting_default = ":clang_tidy_executable_default",
+    visibility = ["//visibility:public"],
+)
+
+
+filegroup(
+    name = "clang_tidy_additional_deps_default",
+    srcs = [],
+)
+
+label_flag(
+    name = "clang_tidy_additional_deps",
+    build_setting_default = ":clang_tidy_additional_deps_default",
+    visibility = ["//visibility:public"],
+)

--- a/clang_tidy/run_clang_tidy.sh
+++ b/clang_tidy/run_clang_tidy.sh
@@ -2,6 +2,9 @@
 # Usage: run_clang_tidy <OUTPUT> [ARGS...]
 set -ue
 
+CLANG_TIDY_BIN=$1
+shift
+
 OUTPUT=$1
 shift
 
@@ -11,4 +14,4 @@ shift
 touch $OUTPUT
 truncate -s 0 $OUTPUT
 
-clang-tidy "$@"
+"${CLANG_TIDY_BIN}" "$@"


### PR DESCRIPTION
Thank you very much for this great project.

I tried to add it to our project. Our project uses a hermetic toolchain build, so I could not do it properly (e.g. remote execution does not work).
I thought I add support for that as well.

The previous usage is not affected, so we support both hermetic and non-hermetic builds. For hermetic builds, this is the way it would work:
```
bazel build //... \
  --aspects @bazel_clang_tidy//clang_tidy:clang_tidy.bzl%clang_tidy_aspect \
  --output_groups=report \
  --@bazel_clang_tidy//:clang_tidy_config=//:clang_tidy_config \
  --@bazel_clang_tidy//:clang_tidy_additional_deps=@local_config_cc//:system_header_files \
  --@bazel_clang_tidy//:clang_tidy_executable=@local_config_cc//:clangtidy_executable
```

- clang_tidy_additional_deps defaults to an empty list
- clang_tidy_executable defaults to an emtpy list -> gets converted to plain `clang-tidy`, so it behaves like before