### PR TITLE
Allow external clang-tidy configs

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -12,10 +12,9 @@ label_flag(
     visibility = ["//visibility:public"],
 )
 
-
 filegroup(
     name = "clang_tidy_executable_default",
-    srcs = [], # empty list: system clang-tidy
+    srcs = [],  # empty list: system clang-tidy
 )
 
 label_flag(
@@ -23,7 +22,6 @@ label_flag(
     build_setting_default = ":clang_tidy_executable_default",
     visibility = ["//visibility:public"],
 )
-
 
 filegroup(
     name = "clang_tidy_additional_deps_default",

--- a/clang_tidy/clang_tidy.bzl
+++ b/clang_tidy/clang_tidy.bzl
@@ -1,7 +1,23 @@
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 
-def _run_tidy(ctx, wrapper, exe, additional_deps, config, flags, compilation_context, infile, discriminator):
-    inputs = depset(direct = [infile, config] + additional_deps.files.to_list() + ([exe.files_to_run.executable] if exe.files_to_run.executable else []), transitive = [compilation_context.headers])
+def _run_tidy(
+        ctx,
+        wrapper,
+        exe,
+        additional_deps,
+        config,
+        flags,
+        compilation_context,
+        infile,
+        discriminator):
+    inputs = depset(
+        direct = (
+            [infile, config] +
+            additional_deps.files.to_list() +
+            ([exe.files_to_run.executable] if exe.files_to_run.executable else [])
+        ),
+        transitive = [compilation_context.headers],
+    )
 
     args = ctx.actions.args()
 
@@ -12,11 +28,14 @@ def _run_tidy(ctx, wrapper, exe, additional_deps, config, flags, compilation_con
 
     # this is consumed by the wrapper script
     if len(exe.files.to_list()) == 0:
-        args.add("clang-tidy")  
+        args.add("clang-tidy")
     else:
         args.add(exe.files_to_run.executable)
 
     args.add(outfile.path)  # this is consumed by the wrapper script
+
+    args.add(config.path)
+
     args.add("--export-fixes", outfile.path)
 
     # add source to check

--- a/clang_tidy/run_clang_tidy.sh
+++ b/clang_tidy/run_clang_tidy.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 # Usage: run_clang_tidy <OUTPUT> [ARGS...]
 set -ue
 
@@ -8,10 +8,17 @@ shift
 OUTPUT=$1
 shift
 
+CONFIG=$1
+shift
+
 # clang-tidy doesn't create a patchfile if there are no errors.
 # make sure the output exists, and empty if there are no errors,
 # so the build system will not be confused.
 touch $OUTPUT
 truncate -s 0 $OUTPUT
+
+# if $CONFIG is provided by some external workspace, we need to
+# place it in the current directory
+test -e .clang-tidy || ln -s -f $CONFIG .clang-tidy
 
 "${CLANG_TIDY_BIN}" "$@"


### PR DESCRIPTION
In the clang-tidy wrapper script, create a symlink in the current working directory to the provided clang-tidy config if not already present.