### PR TITLE
Use source file extension when applying toolchain flags

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,2 @@
+build:clang-tidy --aspects @bazel_clang_tidy//clang_tidy:clang_tidy.bzl%clang_tidy_aspect
+build:clang-tidy --output_groups=report

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "bazel_clang_tidy")

--- a/example/BUILD
+++ b/example/BUILD
@@ -4,6 +4,12 @@ cc_library(
     hdrs = ["lib.hpp"],
 )
 
+cc_library(
+    name = "lib2",
+    srcs = ["lib.c"],
+    hdrs = ["lib.h"],
+)
+
 cc_binary(
     name = "example",
     srcs = ["app.cpp"],

--- a/example/lib.c
+++ b/example/lib.c
@@ -1,0 +1,6 @@
+#include "lib.h"
+
+int foo(int a, int b)
+{
+  return a + b;
+}

--- a/example/lib.h
+++ b/example/lib.h
@@ -1,0 +1,6 @@
+#ifndef EXAMPLE_LIB_H
+#define EXAMPLE_LIB_H
+
+int foo(int a, int b);
+
+#endif /*  EXAMPLE_LIB_H */


### PR DESCRIPTION
Obtain C or C++ flags from the toolchain depending on the source file extension. This prevents use of C++ flags (e.g. -std=c++17) with C source files.