### PR TITLE
Filter Rust targets from aspect

### DIFF
--- a/clang_tidy/clang_tidy.bzl
+++ b/clang_tidy/clang_tidy.bzl
@@ -77,10 +77,22 @@ def _run_tidy(
     return outfile
 
 def _rule_sources(ctx):
+    def check_valid_file_type(src):
+        """
+        Returns True if the file type matches one of the permitted srcs file types for C and C++ header/source files.
+        """
+        permitted_file_types = [
+            ".c", ".cc", ".cpp", ".cxx", ".c++", ".C", ".h", ".hh", ".hpp", ".hxx", ".inc", ".inl", ".H",
+        ]
+        for file_type in permitted_file_types:
+            if src.basename.endswith(file_type):
+                return True
+        return False
+
     srcs = []
     if hasattr(ctx.rule.attr, "srcs"):
         for src in ctx.rule.attr.srcs:
-            srcs += [src for src in src.files.to_list() if src.is_source]
+            srcs += [src for src in src.files.to_list() if src.is_source and check_valid_file_type(src)]
     return srcs
 
 def _toolchain_flags(ctx):


### PR DESCRIPTION
`rust_library` rules contain the `CcInfo` provider, so the bazel aspect does not filter `rust_library` targets and subsequently fails the build. This PR adds a simple check for the `CrateInfo` provider, which seems to be the right way to filter out Rust rules.