### PR TITLE
Exclude external targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ If you have a hermetic build, you can use your own clang-tidy target like this:
 build:clang-tidy --@bazel_clang_tidy//:clang_tidy_executable=@local_config_cc//:clangtidy_bin
 ```
 
+This aspect is not executed on external targets. To exclude other targets,
+users may tag a target with `no-clang-tidy` or `noclangtidy`.
+
 ## Features
 
 - Run clang-tidy on any C++ target

--- a/clang_tidy/clang_tidy.bzl
+++ b/clang_tidy/clang_tidy.bzl
@@ -134,6 +134,16 @@ def _clang_tidy_aspect_impl(target, ctx):
     if target.label.workspace_root.startswith("external"):
         return []
 
+    # Targets with specific tags will not be formatted
+    ignore_tags = [
+        "noclangtidy",
+        "no-clang-tidy",
+    ]
+
+    for tag in ignore_tags:
+        if tag in ctx.rule.attr.tags:
+            return []
+
     wrapper = ctx.attr._clang_tidy_wrapper.files_to_run
     exe = ctx.attr._clang_tidy_executable
     additional_deps = ctx.attr._clang_tidy_additional_deps

--- a/clang_tidy/clang_tidy.bzl
+++ b/clang_tidy/clang_tidy.bzl
@@ -130,6 +130,10 @@ def _clang_tidy_aspect_impl(target, ctx):
     if not CcInfo in target:
         return []
 
+    # Ignore external targets
+    if target.label.workspace_root.startswith("external"):
+        return []
+
     wrapper = ctx.attr._clang_tidy_wrapper.files_to_run
     exe = ctx.attr._clang_tidy_executable
     additional_deps = ctx.attr._clang_tidy_additional_deps


### PR DESCRIPTION
I encountered the same issue as in #46. I also included two tags to allow the exclusion of specific targets, similar to the approach taken by rust_rules.
