### PR TITLE
Add target to be ignored when running clang-tidy

### DIFF
--- a/example/BUILD
+++ b/example/BUILD
@@ -10,8 +10,15 @@ cc_library(
     hdrs = ["lib.h"],
 )
 
+cc_library(
+    name = "lib_ignored",
+    srcs = ["lib_ignored.cpp"],
+    hdrs = ["lib_ignored.hpp"],
+    tags = ["no-clang-tidy"],
+)
+
 cc_binary(
     name = "example",
     srcs = ["app.cpp"],
-    deps = [":lib"],
+    deps = [":lib", ":lib_ignored"],
 )

--- a/example/app.cpp
+++ b/example/app.cpp
@@ -1,9 +1,11 @@
 #include "lib.hpp"
+#include "lib_ignored.hpp"
 
 #include <iostream>
 
 int main()
 {
   std::cout << lib_get_greet_for("World") << "\n";
+  std::cout << lib_with_ignored_warnings("Again") << "\n";
   return 0;
 }

--- a/example/lib_ignored.cpp
+++ b/example/lib_ignored.cpp
@@ -1,0 +1,8 @@
+#include "lib_ignored.hpp"
+
+// Expect performance-unnecessary-value-param clang-tidy warning below.
+// However, this lib is ignored in the BUILD-file and no warning should be generated.
+std::string lib_with_ignored_warnings(std::string name)
+{
+  return "Hello " + name + "!";
+}

--- a/example/lib_ignored.hpp
+++ b/example/lib_ignored.hpp
@@ -1,0 +1,3 @@
+#include <string>
+
+std::string lib_with_ignored_warnings(std::string name);


### PR DESCRIPTION
I added a new library that will be ignored when running clang-tidy as suggested in #47.
Is it ok to put it under example/? Or should I create a tests folder? I also noticed that CI is not running the clang-tidy config when building. If you want I can add a job for that also.