### PR TITLE
test: Can we ignore warnings inside proto header files

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-UseColor: true
+# UseColor: true
 
 Checks: >
     bugprone-*,

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,1 +1,18 @@
 workspace(name = "bazel_clang_tidy")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# ref:https://github.com/zeal-up/ProtoBuf-Bazel/blob/main/WORKSPACE
+http_archive(
+    name = "rules_proto",
+    sha256 = "66bfdf8782796239d3875d37e7de19b1d94301e8972b3cbd2446b332429b4df1",
+    strip_prefix = "rules_proto-4.0.0",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/refs/tags/4.0.0.tar.gz",
+        "https://github.com/bazelbuild/rules_proto/archive/refs/tags/4.0.0.tar.gz",
+    ],
+)
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+rules_proto_dependencies()
+rules_proto_toolchains()
+

--- a/clang_tidy/clang_tidy.bzl
+++ b/clang_tidy/clang_tidy.bzl
@@ -82,6 +82,13 @@ def _rule_sources(ctx):
         """
         Returns True if the file type matches one of the permitted srcs file types for C and C++ header/source files.
         """
+        print(src)
+        ignore_file_types = [
+            ".pb.h",
+        ]
+        for file_type in ignore_file_types:
+            if src.basename.endswith(file_type):
+                return False
         permitted_file_types = [
             ".c", ".cc", ".cpp", ".cxx", ".c++", ".C", ".h", ".hh", ".hpp", ".hxx", ".inc", ".inl", ".H",
         ]

--- a/example/BUILD
+++ b/example/BUILD
@@ -1,3 +1,5 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
 cc_library(
     name = "lib",
     srcs = ["lib.cpp"],
@@ -17,8 +19,30 @@ cc_library(
     tags = ["no-clang-tidy"],
 )
 
+
+# 1. With proto and cc_proto from rules_proto
+# proto_library(
+#     name = "person_proto",
+#     srcs = ["person.proto"],
+#     tags = ["no-clang-tidy"],
+# )
+
+# cc_proto_library(
+#     name = "person_cc_proto",
+#     deps = [":person_proto"],
+#     tags = ["no-clang-tidy"],
+# )
+
+# 2. With cc_proto library from google protobuf, they are somehow not the same
+load("@com_google_protobuf//:protobuf.bzl", "cc_proto_library")
+cc_proto_library(
+    name = "person_cc_proto",
+    srcs = [":person.proto"],
+    tags = ["no-clang-tidy"],
+)
+
 cc_binary(
     name = "example",
     srcs = ["app.cpp"],
-    deps = [":lib", ":lib_ignored"],
+    deps = [":lib", ":lib_ignored", ":person_cc_proto"],
 )

--- a/example/app.cpp
+++ b/example/app.cpp
@@ -1,5 +1,6 @@
 #include "lib.hpp"
 #include "lib_ignored.hpp"
+#include "example/person.pb.h"
 
 #include <iostream>
 

--- a/example/person.proto
+++ b/example/person.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+message Person {
+  string name = 1;
+  int32 id = 2;
+  string email = 3;
+}


### PR DESCRIPTION
Question, how can we make it easier to suppress proto header files complains?

Currently, we are using `HeaderFilterRegex` for this: proto directories are not passed to it. 

Seems recent changes are supporting `no_clang_tidy` tag, I tired to use this tag to make things cleaner.

However, things are not that easy.

I upload the running demo and changes I have made in this patch, please have a look at when you are free.
@erenon @storypku 