### PR TITLE
Only print anything on errors

### DIFF
--- a/clang_tidy/run_clang_tidy.sh
+++ b/clang_tidy/run_clang_tidy.sh
@@ -21,4 +21,8 @@ truncate -s 0 $OUTPUT
 # place it in the current directory
 test -e .clang-tidy || ln -s -f $CONFIG .clang-tidy
 
-"${CLANG_TIDY_BIN}" "$@"
+# Print output on failure only
+logfile="$(mktemp)"
+trap 'if (($?)); then cat "$logfile" 1>&2; fi; rm "$logfile"' EXIT
+
+"${CLANG_TIDY_BIN}" "$@" >"$logfile" 2>&1


### PR DESCRIPTION
Let's have a dark cockpit. With this change, if you have no clang-tidy issues in any file, there will not be any output.