### PR TITLE
Pass through `--sysroot`

### DIFF
--- a/clang_tidy/clang_tidy.bzl
+++ b/clang_tidy/clang_tidy.bzl
@@ -123,7 +123,7 @@ def _safe_flags(flags):
         "-fstack-usage",
     ]
 
-    return [flag for flag in flags if flag not in unsupported_flags and not flag.startswith("--sysroot")]
+    return [flag for flag in flags if flag not in unsupported_flags]
 
 def _clang_tidy_aspect_impl(target, ctx):
     # if not a C/C++ target, we are not interested


### PR DESCRIPTION
clang-tidy supports `--sysroot` and in fact needs it to find header files in some cases.
For example if building with a hermetic compiler and libc++/libstdc++.

The flag was first ignored in https://github.com/erenon/bazel_clang_tidy/commit/c0d0793ccf65ff80920b31f3b60a04eb5fd43372 but I couldn't find a reason as to why the removal was necessary.