### PR TITLE
Add MODULE.bazel file to support Bzlmod

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,1 @@
+module(name = "bazel_clang_tidy")


### PR DESCRIPTION
This PR adds a `MODULE.bazel` file. This is needed for [Bzlmod](https://bazel.build/external/mod-command) support of Bazel. In the long term, this will replace the `WORKSPACE` file. In the meantime, both files are needed.