### PR TITLE
Add external includes to clang-tidy invocation

### DIFF
--- a/clang_tidy/clang_tidy.bzl
+++ b/clang_tidy/clang_tidy.bzl
@@ -66,6 +66,8 @@ def _run_tidy(
 
     args.add_all(compilation_context.system_includes.to_list(), before_each = "-isystem")
 
+    args.add_all(compilation_context.external_includes.to_list(), before_each = "-isystem")
+
     ctx.actions.run(
         inputs = inputs,
         outputs = [outfile],


### PR DESCRIPTION
 - This uses bazel's [`external_includes`](https://bazel.build/rules/lib/builtins/CompilationContext#external_includes) to account for external dependencies' headers (e.g. `@my_library` in `cc_library.deps`)
- Current workaround is to manually add paths via bazel flags, e.g. `build:clang-tidy --copt=-isystem./external/my_library/include`; with this change this is no longer needed
