### PR TITLE
fix: Take `--conlyopt` into consideration

### DIFF
--- a/clang_tidy/clang_tidy.bzl
+++ b/clang_tidy/clang_tidy.bzl
@@ -19,8 +19,8 @@ def _run_tidy(
             ([exe.files_to_run.executable] if exe.files_to_run.executable else [])
         ),
         transitive =
-          [compilation_context.headers for compilation_context in compilation_contexts] +
-          [cc_toolchain.all_files],
+            [compilation_context.headers for compilation_context in compilation_contexts] +
+            [cc_toolchain.all_files],
     )
 
     args = ctx.actions.args()
@@ -132,6 +132,8 @@ def _toolchain_flags(ctx, action_name = ACTION_NAMES.cpp_compile):
     user_compile_flags = ctx.fragments.cpp.copts
     if action_name == ACTION_NAMES.cpp_compile:
         user_compile_flags.extend(ctx.fragments.cpp.cxxopts)
+    elif action_name == ACTION_NAMES.c_compile and hasattr(ctx.fragments.cpp, "conlyopts"):
+        user_compile_flags.extend(ctx.fragments.cpp.conlyopts)
     compile_variables = cc_common.create_compile_variables(
         feature_configuration = feature_configuration,
         cc_toolchain = cc_toolchain,

--- a/clang_tidy/clang_tidy.bzl
+++ b/clang_tidy/clang_tidy.bzl
@@ -19,8 +19,8 @@ def _run_tidy(
             ([exe.files_to_run.executable] if exe.files_to_run.executable else [])
         ),
         transitive =
-            [compilation_context.headers for compilation_context in compilation_contexts] +
-            [cc_toolchain.all_files],
+          [compilation_context.headers for compilation_context in compilation_contexts] +
+          [cc_toolchain.all_files],
     )
 
     args = ctx.actions.args()


### PR DESCRIPTION
Recent C/C++ compilation in Bazel supports the command-line option [`--conlyopt`](https://bazel.build/docs/user-manual#cconlyopt) to specify the options only applied for C (not for C++).

This PR adds the command-line flags generated by the corresponding cpp fragment [`conlyopts`](https://bazel.build/rules/lib/fragments/cpp#conlyopts). For backward compatibility, this change is guarded by `hasattr`.