### PR TITLE
feat: Support a tag to distinguish C files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bazel_clang_tidy
 
-Run clang-tidy on Bazel C++ targets directly,
+Run clang-tidy on Bazel C/C++ targets directly,
 without generating a compile commands database,
 and take advantage of Bazels powerful cache mechanism.
 
@@ -87,7 +87,8 @@ users may tag a target with `no-clang-tidy` or `noclangtidy`.
 
 ## Features
 
-- Run clang-tidy on any C++ target
+- Run clang-tidy on any C/C++ target
+  - A file is treated as C if it has the `.c` extension or its target includes the `clang-tidy-is-c-tu` tag; otherwise, it is treated as C++.
 - Run clang-tidy without also building the target
 - Use Bazel to cache clang-tidy reports: recompute stale reports only
 

--- a/clang_tidy/clang_tidy.bzl
+++ b/clang_tidy/clang_tidy.bzl
@@ -19,8 +19,8 @@ def _run_tidy(
             ([exe.files_to_run.executable] if exe.files_to_run.executable else [])
         ),
         transitive =
-          [compilation_context.headers for compilation_context in compilation_contexts] +
-          [cc_toolchain.all_files],
+            [compilation_context.headers for compilation_context in compilation_contexts] +
+            [cc_toolchain.all_files],
     )
 
     args = ctx.actions.args()
@@ -132,6 +132,8 @@ def _toolchain_flags(ctx, action_name = ACTION_NAMES.cpp_compile):
     user_compile_flags = ctx.fragments.cpp.copts
     if action_name == ACTION_NAMES.cpp_compile:
         user_compile_flags.extend(ctx.fragments.cpp.cxxopts)
+    elif action_name == ACTION_NAMES.c_compile and hasattr(ctx.fragments.cpp, "conlyopts"):
+        user_compile_flags.extend(ctx.fragments.cpp.conlyopts)
     compile_variables = cc_common.create_compile_variables(
         feature_configuration = feature_configuration,
         cc_toolchain = cc_toolchain,

--- a/clang_tidy/clang_tidy.bzl
+++ b/clang_tidy/clang_tidy.bzl
@@ -157,6 +157,21 @@ def _safe_flags(flags):
 
     return [flag for flag in flags if flag not in unsupported_flags]
 
+def _is_c_translation_unit(src, tags):
+    """Judge if a source file is for C.
+
+    Args:
+        src(File): Source file object.
+        tags(list[str]): Tags attached to the target.
+
+    Returns:
+        bool: Whether the source is for C.
+    """
+    if "clang-tidy-is-c-tu" in tags:
+        return True
+
+    return src.extension == "c"
+
 def _clang_tidy_aspect_impl(target, ctx):
     # if not a C/C++ target, we are not interested
     if not CcInfo in target:
@@ -207,7 +222,7 @@ def _clang_tidy_aspect_impl(target, ctx):
             exe,
             additional_deps,
             config,
-            c_flags if src.extension == "c" else cxx_flags,
+            c_flags if _is_c_translation_unit(src, ctx.rule.attr.tags) else cxx_flags,
             compilation_contexts,
             src,
             target.label.name,


### PR DESCRIPTION
Resolves #78

Having the tool recognize a file as C if its target has a tag `clang-tidy-is-c-tu`.