### PR TITLE
Add --verify-config to clang-tidy invocations

### DIFF
--- a/clang_tidy/clang_tidy_test.bzl
+++ b/clang_tidy/clang_tidy_test.bzl
@@ -64,12 +64,12 @@ ln -s .. external
 
 has_srcs=false
 if [[ -n "{c_sources}" ]]; then
-  "$bin" --quiet --export-fixes $TEST_UNDECLARED_OUTPUTS_DIR/cfixes.yaml {c_sources} -- {c_flags}
+  "$bin" --quiet --verify-config --export-fixes $TEST_UNDECLARED_OUTPUTS_DIR/cfixes.yaml {c_sources} -- {c_flags}
   has_srcs=true
 fi
 
 if [[ -n "{cxx_sources}" ]]; then
-  "$bin" --quiet --export-fixes $TEST_UNDECLARED_OUTPUTS_DIR/cxxfixes.yaml {cxx_sources} -- {cxx_flags}
+  "$bin" --quiet --verify-config --export-fixes $TEST_UNDECLARED_OUTPUTS_DIR/cxxfixes.yaml {cxx_sources} -- {cxx_flags}
   has_srcs=true
 fi
 

--- a/clang_tidy/run_clang_tidy.sh
+++ b/clang_tidy/run_clang_tidy.sh
@@ -33,6 +33,7 @@ trap 'if (($?)); then cat "$logfile" 1>&2; fi; rm "$logfile"' EXIT
 # re-promoted to an error. See the clang-tidy bug here for details:
 # https://github.com/llvm/llvm-project/issues/61969
 set -- \
+  --verify-config \
   --checks=-clang-diagnostic-builtin-macro-redefined \
   --warnings-as-errors=-clang-diagnostic-builtin-macro-redefined \
    "$@"


### PR DESCRIPTION
By default clang-tidy ignores unknown checks. This makes that an error
case.
