### PR TITLE
Only use --verify-config to check config

### DIFF
--- a/clang_tidy/run_clang_tidy.sh
+++ b/clang_tidy/run_clang_tidy.sh
@@ -33,9 +33,11 @@ trap 'if (($?)); then cat "$logfile" 1>&2; fi; rm "$logfile"' EXIT
 # re-promoted to an error. See the clang-tidy bug here for details:
 # https://github.com/llvm/llvm-project/issues/61969
 set -- \
-  --verify-config \
   --checks=-clang-diagnostic-builtin-macro-redefined \
   --warnings-as-errors=-clang-diagnostic-builtin-macro-redefined \
    "$@"
 
-"${CLANG_TIDY_BIN}" "$@" >"$logfile" 2>&1
+{
+  "${CLANG_TIDY_BIN}" --quiet --verify-config \
+  && "${CLANG_TIDY_BIN}" "$@"
+} >"$logfile" 2>&1


### PR DESCRIPTION
This is very similar to https://github.com/erenon/bazel_clang_tidy/pull/93, but does the same move in the actual clang tidy script.

I verified that this let clang tidy run in a private repo (where before it would return no errors). It also errors out when there are config errors