### PR TITLE
Explicitly pass --config-file

### DIFF
--- a/clang_tidy/run_clang_tidy.sh
+++ b/clang_tidy/run_clang_tidy.sh
@@ -17,10 +17,6 @@ shift
 touch $OUTPUT
 truncate -s 0 $OUTPUT
 
-# if $CONFIG is provided by some external workspace, we need to
-# place it in the current directory
-test -e .clang-tidy || ln -s -f $CONFIG .clang-tidy
-
 # Print output on failure only
 logfile="$(mktemp)"
 trap 'if (($?)); then cat "$logfile" 1>&2; fi; rm "$logfile"' EXIT
@@ -38,6 +34,6 @@ set -- \
    "$@"
 
 {
-  "${CLANG_TIDY_BIN}" --quiet --verify-config \
-  && "${CLANG_TIDY_BIN}" "$@"
+  "${CLANG_TIDY_BIN}" --config-file=$CONFIG --quiet --verify-config &&
+  "${CLANG_TIDY_BIN}" --config-file=$CONFIG "$@"
 } >"$logfile" 2>&1


### PR DESCRIPTION
It seems like relying on the default .clang-tidy config file means that --verify-config doesn't actually fail the call. This looks like it works when I add random characters to the .clang-tidy file in this repo
```
$ bazel build //... --config clang-tidy
...
Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
.clang-tidy:9:1: error: unknown key 'asdf'
asdf
^~~~
Error: invalid configuration specified.
Invalid argument
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 0.192s, Critical Path: 0.09s
INFO: 7 processes: 4 action cache hit, 7 internal.
ERROR: Build did NOT complete successfully
```